### PR TITLE
Allow hard clearing on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 
 const isWin = process.platform === 'win32';
 
-module.exports = function (isSoft) {
+module.exports = function (isSoft = isWin) {
 	process.stdout.write(
-		(isWin || isSoft) ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H'
+		isSoft ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H'
 	);
 }


### PR DESCRIPTION
There are terminals for Windows that support scrollback clearing (such as MinTTY): consumers should be allowed to utilize this if their terminal supports it.