### PR TITLE
keep all the history

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
-module.exports = function (isSoft) {
+module.exports = function (keepHistory) {
 	process.stdout.write(
-		isSoft ? '\x1B[H\x1B[2J' : '\x1B[2J\x1B[3J\x1B[H\x1Bc'
+		keepHistory
+			? ('\n'.repeat(process.stdout.rows) + '\x1B[H\x1B[2J')
+			: '\x1B[2J\x1B[3J\x1B[H\x1Bc'
 	);
 }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 'use strict';
 
-module.exports = function (keepHistory) {
+module.exports = function (keepHistory, keepLastScreen) {
+	if (keepHistory && keepLastScreen) {
+		process.stdout.write('\n'.repeat(process.stdout.rows));
+	}
 	process.stdout.write(
-		keepHistory
-			? ('\n'.repeat(process.stdout.rows) + '\x1B[H\x1B[2J')
-			: '\x1B[2J\x1B[3J\x1B[H\x1Bc'
+		keepHistory ? '\x1B[H\x1B[2J' : '\x1B[2J\x1B[3J\x1B[H\x1Bc'
 	);
 }


### PR DESCRIPTION
preserve \*all\* the history

before, `clear(true)` removed the last part of the terminal history

now `dont clear me` should be visible when scrolling back

```bash
echo dont clear me; node -e "require('./')(true, true)"
```

edit: should be an extra option, sometimes its desired to keep no history
edit: done. added the option `keepLastScreen`